### PR TITLE
Renamed Quaternion parameter property to quaternion, as proposed in #4

### DIFF
--- a/standard/standard/Instances/GeoPose.Composite.Chain.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Chain.Instance.json
@@ -9,17 +9,17 @@
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     }
   ]
 }

--- a/standard/standard/Instances/GeoPose.Composite.Graph.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Graph.Instance.json
@@ -8,32 +8,32 @@
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "/Intrinsic/Translate-Rotate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[0.69291, 0.69291, 0.14097, 0.14097]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[0.69291, 0.69291, 0.14097, 0.14097]"
     }
   ],
   "transformList": [

--- a/standard/standard/Instances/GeoPose.Composite.Sequence.Series.Irregular.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Sequence.Series.Irregular.Instance.json
@@ -16,7 +16,7 @@
       "frame": {
         "authority": "/geopose/1.0",
         "id": "RotateTranslate",
-        "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+        "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
       },
       "validTime": 1605237062006
     },
@@ -24,7 +24,7 @@
       "frame": {
         "authority": "/geopose/1.0",
         "id": "RotateTranslate",
-        "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+        "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
       },
       "validTime": 1605237062006
     },
@@ -32,7 +32,7 @@
       "frame": {
         "authority": "/geopose/1.0",
         "id": "RotateTranslate",
-        "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+        "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
       },
       "validTime": 1605237062006
     }

--- a/standard/standard/Instances/GeoPose.Composite.Sequence.Series.Regular.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Sequence.Series.Regular.Instance.json
@@ -16,17 +16,17 @@
     {
       "authority": "/geopose/1.0",
       "id": "RotateTranslate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "RotateTranslate",
-      "parameters": "translation=[0.5, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+      "parameters": "translation=[0.5, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
     },
     {
       "authority": "/geopose/1.0",
       "id": "RotateTranslate",
-      "parameters": "translation=[1.0, 0.0, 0.0]&rotation=[1.0, 0.0, 0.0, 0.5]"
+      "parameters": "translation=[1.0, 0.0, 0.0]&quaternion=[1.0, 0.0, 0.0, 0.5]"
     }
   ],
   "trailer": {

--- a/standard/standard/Instances/GeoPose.Composite.Sequence.Stream.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Sequence.Stream.Instance.json
@@ -13,7 +13,7 @@
         "frame": {
           "authority": "/geopose/1.0",
           "id": "RotateTranslate",
-          "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[-0.58793, 0.07988, -0.10838, 0.79763]"
+          "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[-0.58793, 0.07988, -0.10838, 0.79763]"
         },
         "validTime": 1609466694321
       }
@@ -23,7 +23,7 @@
         "frame": {
           "authority": "/geopose/1.0",
           "id": "RotateTranslate",
-          "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[-0.58901, 0.08087, -0.10937, 0.79660]"
+          "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[-0.58901, 0.08087, -0.10937, 0.79660]"
         },
         "validTime": 1609466706667
       }
@@ -33,7 +33,7 @@
         "frame": {
           "authority": "/geopose/1.0",
           "id": "RotateTranslate",
-          "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[-0.59008, 0.08186, -0.11037, 0.79556]"
+          "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[-0.59008, 0.08186, -0.11037, 0.79556]"
         },
         "validTime": 1609466719012
       }

--- a/standard/standard/Instances/GeoPose.Composite.Sequence.StreamElement.Instance.json
+++ b/standard/standard/Instances/GeoPose.Composite.Sequence.StreamElement.Instance.json
@@ -3,7 +3,7 @@
     "frame": {
       "authority": "/geopose/1.0",
       "id": "RotateTranslate",
-      "parameters": "translation=[0.0, 0.0, 0.0]&rotation=[-0.58793, 0.07988, -0.10838, 0.79763]"
+      "parameters": "translation=[0.0, 0.0, 0.0]&quaternion=[-0.58793, 0.07988, -0.10838, 0.79763]"
     },
     "validTime": 1609466694321
   }


### PR DESCRIPTION
Changed in adoc files, assuming html and pdf are generated from them.

In the schemata, the parameter property is defined as string, but haven't found a definition of this strings content. Apologies when I missed this.