### PR TITLE
Update global-cc.yaml

### DIFF
--- a/standard/standard/modspec/yaml/global-cc.yaml
+++ b/standard/standard/modspec/yaml/global-cc.yaml
@@ -8,14 +8,14 @@ scopes:
 
   tests:
   - name: Verify individual standardization targets are independent
-    identifier: /req/global/target-independence
+    identifier: /conf/global/target-independence
     targets:
     - /req/global/target-independence
     purpose: Verify standardization targets are independent.
     method: Inspection
 
   - name: Verify implementation conforms to the logical model
-    identifier: /req/global/logical-model
+    identifier: /conf/global/logical-model
     targets:
     - /req/global/logical-model
     description: |
@@ -26,7 +26,7 @@ scopes:
     method: Inspection
 
   - name: Verify SDU conforms to the "Structural Data Unit - SDU" stereotype
-    identifier: /req/global/sdu
+    identifier: /conf/global/sdu
     targets:
     - /req/global/sdu
     description: |


### PR DESCRIPTION
Fixes https://github.com/opengeospatial/GeoPose/issues/77

The duplicated identifier was detected by the metanorma toolchain.

Since Metanorma version 1.5.4, this edit is required for the document to build.